### PR TITLE
Fix ITMS-90809 error when submit app in store

### DIFF
--- a/ios/flutter_naver_login.podspec
+++ b/ios/flutter_naver_login.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
 
-  s.dependency 'naveridlogin-sdk-ios', '~> 4.0.12'
+  s.dependency 'naveridlogin-sdk-ios', '~> 4.1.0'
 
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
Recently, Apple introduced a new App Submission warning stating that they are formally deprecating UIWebView. 

> ITMS-90809: Deprecated API Usage - **Apple will stop accepting submissions of apps that use UIWebView APIs** . See https://developer.apple.com/documentation/uikit/uiwebview for more information.

**This error blocks applications validation**

Naver has updated their ios-sdk to fix this : [https://github.com/naver/naveridlogin-sdk-ios/commit/41dd4a93192aa16ea39ea3aac6715eb03d741e46](url)

This pull request just update the version of naveridlogin-sdk-ios in podspec to the latest version to be able to submit applications on the store.