### PR TITLE
[iOS] info.plist 설정 관련 내용 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,48 +84,65 @@ After you've done that, find out what your Naver App Client ID is. You can find 
 
 **\<your project root>ios/Runner/Info.plist**
 ```xml
-    <key>LSApplicationQueriesSchemes</key>
-   <array>
-      <string>naversearchapp</string>
-      <string>naversearchthirdlogin</string>
-   </array>
-
-	<key>kServiceAppUrlScheme</key>
-	<string>[UrlScheme]</string>
-	<key>kConsumerKey</key>
-	<string>[ConsumerKey]</string>
-	<key>kConsumerSecret</key>
-	<string>[ConsumerSecret]</string>
-	<key>kServiceAppName</key>
-	<string>[ServiceAppName]</string>
-
-
-   <key>NSAppTransportSecurity</key>
-   <dict>
-      <key>NSAllowsArbitraryLoads</key>
-      <true/>
-      <key>NSExceptionDomains</key>
-      <dict>
-         <key>naver.com</key>
-         <dict>
-            <key>NSExceptionAllowsInsecureHTTPLoads</key>
-            <true/>
-            <key>NSExceptionRequiresForwardSecrecy</key>
-            <false/>
-            <key>NSIncludesSubdomains</key>
-            <true/>
-         </dict>
-         <key>naver.net</key>
-         <dict>
-            <key>NSExceptionAllowsInsecureHTTPLoads</key>
-            <true/>
-            <key>NSExceptionRequiresForwardSecrecy</key>
-            <false/>
-            <key>NSIncludesSubdomains</key>
-            <true/>
-         </dict>
-      </dict>
-   </dict>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+				<!-- other codes -->
+        <key>CFBundleURLTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleTypeRole</key>
+                <string>Editor</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>[UrlScheme]</string>
+                </array>
+            </dict>
+        </array>
+  
+        <key>LSApplicationQueriesSchemes</key>
+        <array>
+            <string>naversearchapp</string>
+            <string>naversearchthirdlogin</string>
+        </array>
+        <key>kServiceAppUrlScheme</key>
+        <string>[UrlScheme]</string>
+        <key>kConsumerKey</key>
+        <string>[ConsumerKey]</string>
+        <key>kConsumerSecret</key>
+        <string>[ConsumerSecret]</string>
+        <key>kServiceAppName</key>
+        <string>[ServiceAppName]</string>
+        
+        <!-- http allows configurations -->
+        <key>NSAppTransportSecurity</key>
+        <dict>
+           <key>NSAllowsArbitraryLoads</key>
+           <true/>
+           <key>NSExceptionDomains</key>
+           <dict>
+              <key>naver.com</key>
+              <dict>
+                 <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                 <true/>
+                 <key>NSExceptionRequiresForwardSecrecy</key>
+                 <false/>
+                 <key>NSIncludesSubdomains</key>
+                 <true/>
+              </dict>
+              <key>naver.net</key>
+              <dict>
+                 <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                 <true/>
+                 <key>NSExceptionRequiresForwardSecrecy</key>
+                 <false/>
+                 <key>NSIncludesSubdomains</key>
+                 <true/>
+              </dict>
+           </dict>
+        </dict>
+    </dict>
+</plist>
 ```
 A sample of a complete Info.plist file can be found [here](https://github.com/yoonjaepark/flutter_naver_login/blob/master/example/ios/Runner/Info.plist).
 


### PR DESCRIPTION
- CFBundleURLTypes 지정 관련 README 보강
- iOS를 모르는 개발자의 경우 `kServiceAppUrlScheme`를 등록하면 custom scheme가 등록되었다는 오해로 인해 설정 누락 발생할 수 있음을 염두하여 내용을 추가했습니다.