### PR TITLE
[iOS] 가이드 수정 추가 요청

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,25 @@ override func application(_ app: UIApplication, open url: URL, options: [UIAppli
 }
 ```
 
+flutter: 3.0.5<=, Dart: 2.17.6<=
+**\<your project root>ios/Runner/AppDelegate.swift**
+```
+import NaverThirdPartyLogin
+
+override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    var applicationResult = false
+    if (!applicationResult) {
+       applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
+    }
+    // if you use other application url process, please add code here.
+    
+    if (!applicationResult) {
+       applicationResult = super.application(app, open: url, options: options)
+    }
+    return applicationResult
+}
+```
+
 ## How do I use it?
 
 The library tries to closely match the native Android & iOS login SDK APIs where possible. For complete API documentation, just see the [source code](). Everything is documented there.

--- a/README.md
+++ b/README.md
@@ -237,13 +237,12 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
     - file - project settings - build system - legacy build system
 
 ### xcode issue
-** Check Your Xcode version **
-When FlutterNaverLogin.logIn() doesn't return anything. if your Naver Social Login works in Android and ios(Naver app is not installed).
+**\<your project root>ios/Runner/AppDelegate.swift**
+1. When FlutterNaverLogin.logIn() doesn't return anything. if your Naver Social Login works in Android and ios(Naver app is not installed).
 Especially if you already face this error with modifing "AppDelegate.swift". Then you should check xcode version. 
 ```Swift Compiler Error (Xcode): 'UIApplicationOpenURLOptionsKey' has been renamed to 'UIApplication.OpenURLOptionsKey'```
 
 xcode: 13.4.1<=, flutter: 3.0.5<=, Dart: 2.17.6<=
-**\<your project root>ios/Runner/AppDelegate.swift**
 ```
 import NaverThirdPartyLogin
 

--- a/README.md
+++ b/README.md
@@ -162,31 +162,11 @@ Add the following code to log in using the Naver app.
 ```
 
 **swift**
-
 **\<your project root>ios/Runner/AppDelegate.swift**
 ```
 import NaverThirdPartyLogin
 
 override func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-    var applicationResult = false
-    if (!applicationResult) {
-       applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
-    }
-    // if you use other application url process, please add code here.
-    
-    if (!applicationResult) {
-       applicationResult = super.application(app, open: url, options: options)
-    }
-    return applicationResult
-}
-```
-
-flutter: 3.0.5<=, Dart: 2.17.6<=
-**\<your project root>ios/Runner/AppDelegate.swift**
-```
-import NaverThirdPartyLogin
-
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
     var applicationResult = false
     if (!applicationResult) {
        applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
@@ -255,3 +235,28 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
     - build - clean - commandRun: flutter run
 1. Showing All Messages: Multiple commands produce '/Users/yoonjaepark/dev/my_app/build/ios/Debug-iphonesimulator/Runner.app/Frameworks/Flutter.framework':
     - file - project settings - build system - legacy build system
+
+### xcode issue
+** Check Your Xcode version **
+When FlutterNaverLogin.logIn() doesn't return anything. if your Naver Social Login works in Android and ios(Naver app is not installed).
+Especially if you already face this error with modifing "AppDelegate.swift". Then you should check xcode version. 
+```Swift Compiler Error (Xcode): 'UIApplicationOpenURLOptionsKey' has been renamed to 'UIApplication.OpenURLOptionsKey'```
+
+xcode: 13.4.1<=, flutter: 3.0.5<=, Dart: 2.17.6<=
+**\<your project root>ios/Runner/AppDelegate.swift**
+```
+import NaverThirdPartyLogin
+
+override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    var applicationResult = false
+    if (!applicationResult) {
+       applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
+    }
+    // if you use other application url process, please add code here.
+    
+    if (!applicationResult) {
+       applicationResult = super.application(app, open: url, options: options)
+    }
+    return applicationResult
+}
+```

--- a/README.md
+++ b/README.md
@@ -162,11 +162,33 @@ Add the following code to log in using the Naver app.
 ```
 
 **swift**
+
 **\<your project root>ios/Runner/AppDelegate.swift**
 ```
 import NaverThirdPartyLogin
 
 override func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    var applicationResult = false
+    if (!applicationResult) {
+       applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
+    }
+    // if you use other application url process, please add code here.
+    
+    if (!applicationResult) {
+       applicationResult = super.application(app, open: url, options: options)
+    }
+    return applicationResult
+}
+```
+
+> ** if you use xcode version is over 10 **
+1. When FlutterNaverLogin.logIn() doesn't return anything. if your Naver Social Login works in Android and ios(Naver app is not installed).
+Especially if you already face this error with modifing "AppDelegate.swift". Then you should check xcode version. 
+```Swift Compiler Error (Xcode): 'UIApplicationOpenURLOptionsKey' has been renamed to 'UIApplication.OpenURLOptionsKey'```
+```
+import NaverThirdPartyLogin
+
+override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
     var applicationResult = false
     if (!applicationResult) {
        applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
@@ -235,27 +257,3 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
     - build - clean - commandRun: flutter run
 1. Showing All Messages: Multiple commands produce '/Users/yoonjaepark/dev/my_app/build/ios/Debug-iphonesimulator/Runner.app/Frameworks/Flutter.framework':
     - file - project settings - build system - legacy build system
-
-### xcode issue
-**\<your project root>ios/Runner/AppDelegate.swift**
-1. When FlutterNaverLogin.logIn() doesn't return anything. if your Naver Social Login works in Android and ios(Naver app is not installed).
-Especially if you already face this error with modifing "AppDelegate.swift". Then you should check xcode version. 
-```Swift Compiler Error (Xcode): 'UIApplicationOpenURLOptionsKey' has been renamed to 'UIApplication.OpenURLOptionsKey'```
-
-xcode: 13.4.1<=, flutter: 3.0.5<=, Dart: 2.17.6<=
-```
-import NaverThirdPartyLogin
-
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    var applicationResult = false
-    if (!applicationResult) {
-       applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
-    }
-    // if you use other application url process, please add code here.
-    
-    if (!applicationResult) {
-       applicationResult = super.application(app, open: url, options: options)
-    }
-    return applicationResult
-}
-```


### PR DESCRIPTION
현재 xcode 10.0 이상 버전 사용시 변경 사항으로 인해 기존 가이드의 AppDelegate.swift의 코드는 잘 적용이 되지 않는 것 같습니다.
Swift Compiler Error (Xcode): 'UIApplicationOpenURLOptionsKey' has been renamed to 'UIApplication.OpenURLOptionsKey'

AppDelegate.swift에서 해당 라인을 기존에서 아래와 같이 일부 수정하여 해결 할 수 있었습니다.
제 xcode 및 flutter 관련 버전은 아래와 같습니다.

> xcode: 13.4.1, flutter: 3.0.5, Dart: 2.17.6

```
    override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
        var applicationResult = false
        if (!applicationResult) {
           applicationResult = NaverThirdPartyLoginConnection.getSharedInstance().application(app, open: url, options: options)
        }
        // if you use other application url process, please add code here.

        if (!applicationResult) {
           applicationResult = super.application(app, open: url, options: options)
        }
        return applicationResult
    }
```

https://github.com/yoonjaepark/flutter_naver_login/pull/60 PR에 추가적으로 해당 내용을 추가해두면 
https://github.com/yoonjaepark/flutter_naver_login/issues/25 관련 issue가 줄어들 것으로 생각됩니다.

아래는 참고자료입니다.
https://stackoverflow.com/questions/51950230/i-opened-my-app-in-xcode-10-and-now-i-have-errors-in-9-4-1-sdkapplicationdeleg
https://medium.com/@coolanil.saini/upgrade-your-project-to-support-xcode-10-1-and-swift-4-2-14fcb1daa200

감사합니다.
