### PR TITLE
Update to naver login sdk 5.1.1 + clean code (example + kotlin)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.yoonjaepark.flutter_naver_login'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()
@@ -31,7 +31,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
@@ -40,6 +40,7 @@ android {
 }
 
 dependencies {
-    implementation ('com.navercorp.nid:oauth-jdk8:5.0.1')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "com.navercorp.nid:oauth:5.2.0" // jdk 11
+    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,7 +40,6 @@ android {
 }
 
 dependencies {
-    implementation "com.navercorp.nid:oauth:5.2.0" // jdk 11
-    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "com.navercorp.nid:oauth:5.1.1" // jdk 11
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion flutter.compileSdkVersion
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.yoonjaepark.flutter_naver_login_example"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -60,6 +60,7 @@ flutter {
 }
 
 dependencies {
+    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -60,7 +60,6 @@ flutter {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:1.3.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -31,9 +31,6 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <activity android:name="com.navercorp.nid.oauth.activity.NidOAuthWebViewActivity"
-                  android:theme="@style/LaunchTheme">
-        </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="flutter_naver_login_example"
         android:label="flutter_naver_login_example"
         android:icon="@mipmap/ic_launcher">
         <meta-data
@@ -24,7 +24,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/example/android/app/src/main/kotlin/com/yoonjaepark/flutter_naver_login_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/yoonjaepark/flutter_naver_login_example/MainActivity.kt
@@ -1,12 +1,5 @@
 package com.yoonjaepark.flutter_naver_login_example
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity
-import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugins.GeneratedPluginRegistrant
 
-class MainActivity: FlutterActivity() {
-    override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
-        GeneratedPluginRegistrant.registerWith(flutterEngine);
-    }
-}
+class MainActivity: FlutterActivity() {}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,174 +1,168 @@
 import 'package:flutter/material.dart';
 import 'dart:async';
 
-import 'package:flutter/services.dart';
 import 'package:flutter_naver_login/flutter_naver_login.dart';
+
+final GlobalKey<ScaffoldMessengerState> snackbarKey =
+    GlobalKey<ScaffoldMessengerState>();
 
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
+    return MaterialApp(
       title: 'Flutter Naver Login',
-      theme: new ThemeData(
+      scaffoldMessengerKey: snackbarKey,
+      theme: ThemeData(
         primarySwatch: Colors.green,
         primaryColor: const Color(0xFF00c73c),
-        accentColor: const Color(0xFF2196f3),
         canvasColor: const Color(0xFFfafafa),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            textStyle: TextStyle(
+              fontSize: 12.0,
+              color: Colors.black,
+              fontWeight: FontWeight.normal,
+              fontFamily: "Roboto",
+            ),
+          ),
+        ),
       ),
-      home: new MyHomePage(),
+      home: const MyHomePage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  const MyHomePage({Key? key}) : super(key: key);
   @override
   _MyHomePageState createState() => new _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
   bool isLogin = false;
-
   String? accesToken;
-
   String? expiresAt;
-
   String? tokenType;
-
   String? name;
-
   String? refreshToken;
 
-  @override
-  void initState() {
-    super.initState();
+  /// Show [error] content in a ScaffoldMessenger snackbar
+  void _showSnackError(String error) {
+    snackbarKey.currentState?.showSnackBar(
+      SnackBar(
+        backgroundColor: Colors.red,
+        content: Text(error.toString()),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    return new Scaffold(
-      appBar: new AppBar(
-        title: new Text(
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
           'Flutter Naver Login Sample',
           style: TextStyle(color: Colors.white),
         ),
       ),
-      body: new Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          mainAxisSize: MainAxisSize.max,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            new Column(
-              children: <Widget>[
-                new Text('isLogin: $isLogin\n'),
-                new Text('accesToken: $accesToken\n'),
-                new Text('refreshToken: $refreshToken\n'),
-                new Text('tokenType: $tokenType\n'),
-                new Text('user: $name\n'),
-              ],
-            ),
-            new FlatButton(
-                key: null,
-                onPressed: buttonLoginPressed,
-                child: new Text(
-                  "LogIn",
-                  style: new TextStyle(
-                      fontSize: 12.0,
-                      color: Colors.black,
-                      fontWeight: FontWeight.normal,
-                      fontFamily: "Roboto"),
-                )),
-            new FlatButton(
-                key: null,
-                onPressed: buttonLogoutPressed,
-                child: new Text(
-                  "LogOut",
-                  style: new TextStyle(
-                      fontSize: 12.0,
-                      color: Colors.black,
-                      fontWeight: FontWeight.normal,
-                      fontFamily: "Roboto"),
-                )),
-            new FlatButton(
-            key: null,
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 20),
+        children: [
+          Column(
+            children: [
+              Text('isLogin: $isLogin\n'),
+              Text('accesToken: $accesToken\n'),
+              Text('refreshToken: $refreshToken\n'),
+              Text('tokenType: $tokenType\n'),
+              Text('user: $name\n'),
+            ],
+          ),
+          ElevatedButton(
+            onPressed: buttonLoginPressed,
+            child: const Text("LogIn"),
+          ),
+          ElevatedButton(
+            onPressed: buttonLogoutPressed,
+            child: const Text("LogOut"),
+          ),
+          ElevatedButton(
             onPressed: buttonLogoutAndDeleteTokenPressed,
-            child: new Text(
-              "LogOutAndDeleteToken",
-              style: new TextStyle(
-                  fontSize: 12.0,
-                  color: Colors.black,
-                  fontWeight: FontWeight.normal,
-                  fontFamily: "Roboto"),
-            )),
-            new FlatButton(
-                key: null,
-                onPressed: buttonTokenPressed,
-                child: new Text(
-                  "GetToken",
-                  style: new TextStyle(
-                      fontSize: 12.0,
-                      color: Colors.black,
-                      fontWeight: FontWeight.normal,
-                      fontFamily: "Roboto"),
-                )),
-            new FlatButton(
-                key: null,
-                onPressed: buttonGetUserPressed,
-                child: new Text(
-                  "GetUser",
-                  style: new TextStyle(
-                      fontSize: 12.0,
-                      color: Colors.black,
-                      fontWeight: FontWeight.normal,
-                      fontFamily: "Roboto"),
-                ))
-          ]),
+            child: const Text("LogOutAndDeleteToken"),
+          ),
+          ElevatedButton(
+            onPressed: buttonTokenPressed,
+            child: const Text("GetToken"),
+          ),
+          ElevatedButton(
+            onPressed: buttonGetUserPressed,
+            child: const Text("GetUser"),
+          )
+        ],
+      ),
     );
   }
 
   Future<void> buttonLoginPressed() async {
-    NaverLoginResult res = await FlutterNaverLogin.logIn();
-    setState(() {
-      name = res.account.nickname;
-      isLogin = true;
-    });
+    try {
+      final NaverLoginResult res = await FlutterNaverLogin.logIn();
+      setState(() {
+        name = res.account.nickname;
+        isLogin = true;
+      });
+    } catch (error) {
+      _showSnackError(error.toString());
+    }
   }
 
   Future<void> buttonTokenPressed() async {
-    NaverAccessToken res = await FlutterNaverLogin.currentAccessToken;
-    setState(() {
-      refreshToken = res.refreshToken;
-      accesToken = res.accessToken;
-      tokenType = res.tokenType;
-    });
+    try {
+      final NaverAccessToken res = await FlutterNaverLogin.currentAccessToken;
+      setState(() {
+        refreshToken = res.refreshToken;
+        accesToken = res.accessToken;
+        tokenType = res.tokenType;
+      });
+    } catch (error) {
+      _showSnackError(error.toString());
+    }
   }
 
   Future<void> buttonLogoutPressed() async {
-    NaverLoginResult res = await FlutterNaverLogin.logOut();
-    setState(() {
-      isLogin = false;
-      accesToken = null;
-      tokenType = null;
-      name = null;
-    });
+    try {
+      await FlutterNaverLogin.logOut();
+      setState(() {
+        isLogin = false;
+        accesToken = null;
+        tokenType = null;
+        name = null;
+      });
+    } catch (error) {
+      _showSnackError(error.toString());
+    }
   }
 
   Future<void> buttonLogoutAndDeleteTokenPressed() async {
-    NaverLoginResult res = await FlutterNaverLogin.logOutAndDeleteToken();
-    setState(() {
-      isLogin = false;
-      accesToken = null;
-      tokenType = null;
-      name = null;
-    });
+    try {
+      await FlutterNaverLogin.logOutAndDeleteToken();
+      setState(() {
+        isLogin = false;
+        accesToken = null;
+        tokenType = null;
+        name = null;
+      });
+    } catch (error) {
+      _showSnackError(error.toString());
+    }
   }
 
   Future<void> buttonGetUserPressed() async {
-    NaverAccountResult res = await FlutterNaverLogin.currentAccount();
-    setState(() {
-      name = res.name;
-    });
+    try {
+      final NaverAccountResult res = await FlutterNaverLogin.currentAccount();
+      setState(() => name = res.name);
+    } catch (error) {
+      _showSnackError(error.toString());
+    }
   }
 }


### PR DESCRIPTION
Update to naver login sdk 5.1.1

Clean `FlutterNaverLoginPlugin.kt`
 - remove unused private variables 
 - adapt logic to android v2

Clean example :
  - Switch to android v2
  - Use const and theme

----
**NOTE**
I think it would be good to publish this PR alone (without my second one #73), so in case of an error, we can switch between sdk versions.
---