### PR TITLE
Update to naver sdk 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://img.shields.io/badge/pub-v1.6.0-success.svg)](https://travis-ci.org/roughike/flutter_naver_login)
 [![Build Status](https://img.shields.io/badge/pod-v1.6.1-success.svg)](https://travis-ci.org/roughike/flutter_naver_login)
 [![Build Status](https://img.shields.io/badge/ios-10.0-success.svg)](https://travis-ci.org/roughike/flutter_naver_login)
-[![Build Status](https://img.shields.io/badge/naverSDK-v4.0.12-success.svg)](https://travis-ci.org/roughike/flutter_naver_login)
+[![Build Status](https://img.shields.io/badge/naverSDK-v5.2.0-success.svg)](https://travis-ci.org/roughike/flutter_naver_login)
 [![Build Status](https://img.shields.io/badge/build-passing-success.svg)](https://travis-ci.org/roughike/flutter_naver_login)
 
 A Flutter plugin for using the native Naver Login SDKs on Android and iOS.
@@ -64,6 +64,14 @@ Then simply copy and paste into _ROOT_.
 
 
 A sample of the file can be found here. [here](https://github.com/yoonjaepark/flutter_naver_login/blob/master/example/android/app/src/main/AndroidManifest.xml).
+
+It is also necessary to uses `FlutterFragmentActivity` instead of `FlutterActivity` since uses of naver sdk 5.2.0.
+
+```kotlin
+import io.flutter.embedding.android.FlutterFragmentActivity
+
+class MainActivity: FlutterFragmentActivity()
+```
 
 Done!
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ android {
 }
 
 dependencies {
-    implementation "com.navercorp.nid:oauth:5.1.1" // jdk 11
+    implementation "com.navercorp.nid:oauth:5.2.0" // jdk 11
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/android/src/main/kotlin/com/yoonjaepark/flutter_naver_login/FlutterNaverLoginPlugin.kt
+++ b/android/src/main/kotlin/com/yoonjaepark/flutter_naver_login/FlutterNaverLoginPlugin.kt
@@ -2,11 +2,16 @@ package com.yoonjaepark.flutter_naver_login
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.AsyncTask
 import android.os.Bundle
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -50,8 +55,12 @@ class FlutterNaverLoginPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
 
   private var channel: MethodChannel? = null
 
-  private var binding: ActivityPluginBinding? = null
   private lateinit var context: Context
+  private lateinit var launcher: ActivityResultLauncher<Intent>
+
+  // pendingResult in login function
+  // used to call flutter result in launcher
+  private var pendingResult: MethodChannel.Result? = null
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_naver_login")
@@ -84,7 +93,6 @@ class FlutterNaverLoginPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     channel = null
   }
 
-
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
   // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
   // plugin registration via this function while apps migrate to use the new Android APIs
@@ -102,8 +110,28 @@ class FlutterNaverLoginPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     }
   }
 
-  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-    this.binding = binding
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {  
+    this.launcher = (binding.activity as FragmentActivity).registerForActivityResult<Intent, ActivityResult>(ActivityResultContracts.StartActivityForResult()) {
+      result: ActivityResult ->
+
+      if(pendingResult != null) {
+        if (result.resultCode == Activity.RESULT_OK) {
+          currentAccount(pendingResult!!)
+        } else if (result.resultCode == Activity.RESULT_CANCELED) {
+            val errorCode = NaverIdLoginSDK.getLastErrorCode().code
+            val errorDesc = NaverIdLoginSDK.getLastErrorDescription()
+            pendingResult!!.success(object : HashMap<String, String>() {
+              init {
+                put("status", "error")
+                put("errorMessage", "errorCode:$errorCode, errorDesc:$errorDesc")
+              }
+            })
+        } else {
+          pendingResult!!.success(null)
+        }
+      }
+      pendingResult = null
+    }
   }
 
   override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
@@ -115,7 +143,6 @@ class FlutterNaverLoginPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   override fun onDetachedFromActivity() {
-    binding = null
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -160,6 +187,8 @@ class FlutterNaverLoginPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   private fun login(result: Result) {
+    pendingResult = result
+
     val mOAuthLoginHandler = object : OAuthLoginCallback {
       override fun onSuccess() {
         currentAccount(result)
@@ -179,7 +208,7 @@ class FlutterNaverLoginPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       }
     }
 
-    NaverIdLoginSDK.authenticate(context, mOAuthLoginHandler);
+    NaverIdLoginSDK.authenticate(context, launcher, mOAuthLoginHandler);
   }
 
   fun logout(result: Result) {

--- a/example/android/app/src/main/kotlin/com/yoonjaepark/flutter_naver_login_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/yoonjaepark/flutter_naver_login_example/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.yoonjaepark.flutter_naver_login_example
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity() {}
+class MainActivity: FlutterFragmentActivity()


### PR DESCRIPTION
Naver login sdk 5.2.0 released a couple of days ago.

Fixes #66, #58, #56.

This PR includes #72 changes as well, sorry if it is a mess. I can solve the conflicts once you merged #72.

Example as been updated for this version as well. It is important that app MainActivity implements now FlutterFragmentActivity to be compatible with this sdk.

---
**NOTE**
 I think it would be good to publish different plugins version for both pr #72 and #73, in case of an error, we can switch between sdk versions.
---
