### PR TITLE
fix: removed references to deprecated v1

### DIFF
--- a/android/src/main/kotlin/com/yoonjaepark/flutter_naver_login/FlutterNaverLoginPlugin.kt
+++ b/android/src/main/kotlin/com/yoonjaepark/flutter_naver_login/FlutterNaverLoginPlugin.kt
@@ -20,7 +20,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -111,23 +110,6 @@ class FlutterNaverLoginPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
         _applicationContext = null
         channel?.setMethodCallHandler(null)
         channel = null
-    }
-
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    companion object {
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            val channel = MethodChannel(registrar.messenger(), "flutter_naver_login")
-            channel.setMethodCallHandler(FlutterNaverLoginPlugin())
-        }
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {


### PR DESCRIPTION
remove android deprecated v1 code.

## error
```
Unresolved reference 'Registrar'.
Unresolved reference 'messenger'
```