### PR TITLE
Flutter 3.29 및 그 이상의 버전에서는  Registrar 를 사용할 수 없다.

### DIFF
--- a/android/src/main/kotlin/com/yoonjaepark/flutter_naver_login/FlutterNaverLoginPlugin.kt
+++ b/android/src/main/kotlin/com/yoonjaepark/flutter_naver_login/FlutterNaverLoginPlugin.kt
@@ -20,7 +20,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
+// import io.flutter.plugin.common.PluginRegistry.Registrar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -122,6 +122,9 @@ class FlutterNaverLoginPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
     // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
     // depending on the user's project. onAttachedToEngine or registerWith must both be defined
     // in the same class.
+    /*
+    Flutter 3.29 및 그 이상의 버전에서는  Registrar 를 사용할 수 없다.
+    * 참고: https://medium.com/@bmerdogan/flutter-3-29-deprecates-pluginregistry-registrar-migration-guide-0f206232b768
     companion object {
         @JvmStatic
         fun registerWith(registrar: Registrar) {
@@ -129,6 +132,7 @@ class FlutterNaverLoginPlugin : FlutterPlugin, MethodCallHandler, ActivityAware 
             channel.setMethodCallHandler(FlutterNaverLoginPlugin())
         }
     }
+    */
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         this.activity = binding.activity


### PR DESCRIPTION
실제 동작 여부 테스트는 하지 않았고 단지 빌드 에러 수정을 위해 아래 참고 페이지를 기반으로 수정하였습니다. 

* 참고: https://medium.com/@bmerdogan/flutter-3-29-deprecates-pluginregistry-registrar-migration-guide-0f206232b768