### PR TITLE
Flutter 3.35 대응 / R8 Full mode 대응

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group = "com.example.flutter_naver_login"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.8.22"
+    ext.kotlin_version = "2.1.0"
     repositories {
         google()
         mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,7 @@ android {
 
     defaultConfig {
         minSdk = 21
+        consumerProguardFiles("proguard-rules.pro")
     }
 
     dependencies {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,191 @@
+# Flutter Naver Login Plugin ProGuard Rules
+# These rules are automatically applied when using this library with R8/ProGuard
+
+# === R8 FULL MODE SETTINGS ===
+# Full mode enabled - all optimizations active
+# Comment out lines below and uncomment compatibility mode lines if issues persist
+# -android
+# -dontoptimize
+
+# Fix for XmlPullParser issue
+-dontwarn org.xmlpull.v1.**
+-keep class org.xmlpull.** { *; }
+-keep interface org.xmlpull.** { *; }
+
+# Keep Flutter plugin entry point
+-keep class com.example.flutter_naver_login.FlutterNaverLoginPlugin {
+    public <init>();
+    public *;
+}
+
+# Keep ALL Naver SDK classes - R8 aggressive optimization breaks the SDK
+-keep class com.navercorp.** { *; }
+-keep interface com.navercorp.** { *; }
+-keep enum com.navercorp.** { *; }
+
+# Keep NHN legacy classes if present
+-keep class com.nhn.** { *; }
+-keep interface com.nhn.** { *; }
+-keep enum com.nhn.** { *; }
+
+# Keep all classes that might be accessed via reflection
+-keepclasseswithmembers class * {
+    @com.navercorp.nid.* <methods>;
+}
+-keepclasseswithmembers class * {
+    @com.navercorp.nid.* <fields>;
+}
+
+# Keep data classes used for serialization
+-keepclassmembers class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Suppress warnings for Naver SDK
+-dontwarn com.navercorp.nid.**
+-dontwarn com.nhn.android.naverlogin.**
+
+# Keep Kotlin metadata for reflection
+-keepattributes *Annotation*
+-keepattributes Signature
+-keepattributes Exceptions
+-keepattributes InnerClasses
+-keepattributes EnclosingMethod
+
+# Preserve generic type information for R8 Full Mode
+-keepattributes RuntimeVisibleAnnotations
+-keepattributes RuntimeInvisibleAnnotations
+-keepattributes RuntimeVisibleParameterAnnotations
+-keepattributes RuntimeInvisibleParameterAnnotations
+
+# Android XML parser
+-keep class android.content.res.XmlResourceParser { *; }
+-dontwarn android.content.res.XmlResourceParser
+
+# Ignore missing Google Play Core library classes (optional dependency)
+-dontwarn com.google.android.play.core.splitcompat.**
+-dontwarn com.google.android.play.core.splitinstall.**
+-dontwarn com.google.android.play.core.tasks.**
+
+# Ignore missing error-prone annotations
+-dontwarn com.google.errorprone.annotations.**
+
+# Ignore missing Conscrypt classes (optional SSL provider)
+-dontwarn org.conscrypt.**
+
+# Ignore missing OpenJSSE classes (optional SSL provider)
+-dontwarn org.openjsse.**
+
+# Ignore missing Google API Client classes
+-dontwarn com.google.api.client.**
+-dontwarn org.joda.time.**
+
+# Google Crypto Tink (optional dependency)
+-dontwarn com.google.crypto.tink.**
+
+# OkHttp platform detection
+-dontwarn okhttp3.internal.platform.**
+
+# ========== CRITICAL: R8 Full Mode Compatibility Rules ==========
+
+# Gson - JSON serialization library used by Naver SDK
+-keepattributes Signature
+-keep class sun.misc.Unsafe { *; }
+-keep class com.google.gson.stream.** { *; }
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+-keepclassmembers,allowobfuscation class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Fix for java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken
+-keepclassmembers class * extends com.google.gson.reflect.TypeToken {
+    <fields>;
+    <methods>;
+}
+
+# Retrofit - HTTP client used by Naver SDK
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+-keep interface retrofit2.** { *; }
+-keep class retrofit2.** { *; }
+-keepclasseswithmembers class * {
+    @retrofit2.* <methods>;
+}
+
+# Retrofit with Gson converter
+-keep class * implements retrofit2.Converter$Factory
+-keep class * implements retrofit2.CallAdapter$Factory
+
+# Moshi - Alternative JSON library used by Naver SDK
+-keep class com.squareup.moshi.** { *; }
+-keep interface com.squareup.moshi.** { *; }
+-keep class * extends com.squareup.moshi.JsonAdapter
+-keep @com.squareup.moshi.JsonQualifier interface *
+-keepclassmembers class * {
+    @com.squareup.moshi.Json <fields>;
+}
+
+# Kotlin reflection - Critical for Moshi Kotlin support
+-keep class kotlin.reflect.** { *; }
+-keep class kotlin.Metadata { *; }
+-keepclassmembers class kotlin.Metadata {
+    public <methods>;
+}
+-keepclassmembers class * {
+    @kotlin.Metadata <methods>;
+}
+
+# OkHttp - HTTP client
+-keep class okhttp3.** { *; }
+-keep interface okhttp3.** { *; }
+-dontwarn okhttp3.**
+-dontwarn okio.**
+
+# Fix generic type erasure issues in R8 Full Mode
+-keepclassmembers class * {
+    @retrofit2.http.* <methods>;
+}
+-keep class * implements java.lang.reflect.ParameterizedType { *; }
+-keep class java.lang.reflect.ParameterizedType { *; }
+
+# Keep classes that extend generic base classes (common source of cast exceptions)
+-keep class * extends java.lang.reflect.Type { *; }
+-keep class * implements java.lang.reflect.Type { *; }
+
+# CRITICAL: Prevent R8 from optimizing away generic type information
+-keep,allowobfuscation class ** {
+    java.lang.reflect.Type getGenericSuperclass();
+    java.lang.reflect.Type[] getGenericInterfaces();
+}
+-keepclassmembers class * {
+    java.lang.Class getSuperclass();
+    java.lang.Class[] getInterfaces();
+}
+
+# Keep all Type and ParameterizedType implementations in Naver SDK
+-keep class com.navercorp.** implements java.lang.reflect.Type { *; }
+-keep class com.navercorp.** implements java.lang.reflect.ParameterizedType { *; }
+
+# Keep TypeToken pattern used by Gson
+-keep class * extends com.google.gson.reflect.TypeToken { 
+    protected <init>();
+    public <init>();
+}
+
+# Preserve generic signatures of all Naver SDK classes
+-keep,allowobfuscation,allowshrinking class com.navercorp.** {
+    <fields>;
+    <methods>;
+}
+-keepattributes Signature
+-keepattributes *Annotation*
+
+# Keep Retrofit's generic type handling
+-keep,allowobfuscation class retrofit2.DefaultCallAdapterFactory { *; }
+-keep,allowobfuscation class retrofit2.CompletableFutureCallAdapterFactory { *; }

--- a/android/src/main/kotlin/com/example/flutter_naver_login/FlutterNaverLoginPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_naver_login/FlutterNaverLoginPlugin.kt
@@ -1,6 +1,7 @@
 package com.example.flutter_naver_login
 
 import android.app.Activity
+import androidx.annotation.Keep
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -71,6 +72,7 @@ enum class FlutterPluginMethod {
 }
 
 /** FlutterNaverLoginPlugin */
+@Keep
 class FlutterNaverLoginPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     /// The MethodChannel that will facilitate communication between Flutter and native Android

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
#132 

## 문제 상황

Flutter Naver Login 플러그인이 R8 Full Mode에서 다음과 같은 문제가 발생했습니다.

### 증상
- R8 Full Mode 활성화 시 Naver 로그인 실패
- `ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType` 에러 발생
- 로그인 시도 시 NidOAuthBridgeActivity가 즉시 종료

### 근본 원인
R8 Full Mode의 공격적인 최적화가 Naver SDK가 의존하는 리플렉션 기반 제네릭 타입 정보를 제거하여 발생

## 해결 방법

### 1. ProGuard Consumer Rules 추가

플러그인의 `android/proguard-rules.pro` 파일에 다음 규칙들을 추가:

```proguard
# === R8 FULL MODE SETTINGS ===
# Full mode enabled - all optimizations active
# Comment out lines below and uncomment compatibility mode lines if issues persist
# -android
# -dontoptimize

# Keep ALL Naver SDK classes
-keep class com.navercorp.** { *; }
-keep interface com.navercorp.** { *; }
-keep enum com.navercorp.** { *; }

# Critical: Prevent R8 from optimizing away generic type information
-keep,allowobfuscation class ** {
    java.lang.reflect.Type getGenericSuperclass();
    java.lang.reflect.Type[] getGenericInterfaces();
}

# Keep TypeToken pattern used by Gson
-keep class * extends com.google.gson.reflect.TypeToken { 
    protected <init>();
    public <init>();
}

# Preserve generic signatures
-keepattributes Signature
-keepattributes *Annotation*
```

### 2. Gradle 설정

`android/build.gradle`에 consumer ProGuard 규칙 적용:

```gradle
android {
    defaultConfig {
        minSdk = 21
        consumerProguardFiles("proguard-rules.pro")
    }
}
```

## 기술적 분석

### 문제 발생 메커니즘

1. **제네릭 타입 소거 (Generic Type Erasure)**
   - R8 Full Mode는 제네릭 타입 정보를 제거하여 APK 크기를 줄임
   - Naver SDK는 Gson/Retrofit을 통해 런타임에 제네릭 타입 정보를 참조
   - TypeToken 패턴 사용 시 ParameterizedType으로의 캐스팅 실패

2. **리플렉션 메타데이터 제거**
   - Kotlin/Java 리플렉션 메타데이터가 제거되어 JSON 직렬화/역직렬화 실패
   - Moshi/Gson이 필요로 하는 클래스 구조 정보 손실

3. **메서드/필드 인라이닝**
   - R8이 메서드를 인라이닝하여 리플렉션으로 접근할 수 없게 됨

### 해결 원리

1. **제네릭 타입 정보 보존**
   ```proguard
   -keepattributes Signature
   -keep class * extends com.google.gson.reflect.TypeToken
   ```
   - Signature 속성 유지로 제네릭 타입 정보 보존
   - TypeToken 패턴 클래스 유지

2. **리플렉션 메서드 보호**
   ```proguard
   -keep,allowobfuscation class ** {
       java.lang.reflect.Type getGenericSuperclass();
       java.lang.reflect.Type[] getGenericInterfaces();
   }
   ```
   - 제네릭 타입 접근 메서드 보존
   - 난독화는 허용하되 제거는 방지

3. **Naver SDK 전체 보호**
   ```proguard
   -keep class com.navercorp.** { *; }
   ```
   - SDK 내부 구조를 완전히 보존
   - 리플렉션으로 접근되는 모든 요소 보호

## R8 모드 비교

### Compatibility Mode (-android -dontoptimize)
- **장점**: 안정적, 호환성 문제 없음
- **단점**: APK 크기 최적화 제한, 성능 최적화 제한

### Full Mode (기본)
- **장점**: 최대 APK 크기 감소, 성능 최적화
- **단점**: 리플렉션 기반 라이브러리 호환성 문제 가능
- **해결**: 적절한 ProGuard 규칙으로 해결 가능

## 테스트 검증

### 테스트 절차
1. R8 Full Mode 활성화 (`proguard-android-optimize.txt` 사용)
2. Release 빌드 생성
3. Naver 로그인 테스트
4. 토큰 획득 및 사용자 정보 조회 확인

### 성공 지표
- ClassCastException 없이 로그인 성공
- Access Token 정상 획득
- 사용자 프로필 정보 정상 조회

## 권장사항

### 앱 개발자를 위한 가이드

1. **기본 설정 사용**
   - 플러그인의 consumer ProGuard 규칙이 자동 적용됨
   - 추가 설정 불필요

2. **문제 발생 시**
   - 먼저 플러그인 버전 업데이트 확인
   - 그래도 문제 지속 시 Compatibility Mode 사용 고려

3. **APK 크기 최적화**
   - Full Mode 사용 권장
   - 플러그인이 제공하는 ProGuard 규칙으로 충분

## 버전 정보

- Flutter Naver Login Plugin: 2.x.x
- Naver Android SDK: 5.10.0
- 최소 Android SDK: 21
- R8 버전: AGP 8.0+ 기본 포함

## 참고 자료

- [R8 Documentation](https://developer.android.com/studio/build/shrink-code)
- [ProGuard Rules](https://www.guardsquare.com/manual/configuration/usage)
- [Naver Login SDK](https://developers.naver.com/docs/login/android/)
